### PR TITLE
More permissive setTexuture. Change from ofTexture to ofBaseDraws.

### DIFF
--- a/example-kaleidoscope/src/testApp.cpp
+++ b/example-kaleidoscope/src/testApp.cpp
@@ -11,7 +11,7 @@ void testApp::setup(){
 void testApp::update(){
     video.update();
     
-    kal.setTexture(video.getTextureReference());
+    kal.setTexture(video);
     kal.setRotation(ofGetElapsedTimef()*0.1);
     kal.update();
 }

--- a/src/ofxFXObject.cpp
+++ b/src/ofxFXObject.cpp
@@ -221,7 +221,7 @@ bool ofxFXObject::compileCode(){
 }
 
 // A simplified way of filling the insides texture
-void ofxFXObject::setTexture(ofTexture& tex, int _texNum){ 
+void ofxFXObject::setTexture(ofBaseDraws& tex, int _texNum){ 
     if ((_texNum < nTextures) && ( _texNum >= 0)){
         textures[_texNum].begin(); 
         ofClear(0,0);

--- a/src/ofxFXObject.h
+++ b/src/ofxFXObject.h
@@ -67,7 +67,7 @@ public:
     
     void            setPasses(int _passes) { passes = _passes; };
     void            setInternalFormat(int _internalFormat) { internalFormat = _internalFormat; compileCode(); };
-    virtual void    setTexture(ofTexture& tex, int _texNum = 0);
+    virtual void    setTexture(ofBaseDraws& tex, int _texNum = 0);
     
     virtual void    begin(int _texNum = 0);
 	virtual void    end(int _texNum = 0);


### PR DESCRIPTION
ofxFXObject.setTexture don't actually need it's argument to have ofTexture specific capabilities. The only needed capability is drawing, so ofBaseDraws allows a more versatile usage, and as ofTexture extends it, the change is backwards compatible.

This pull request changes the type of the argument and updates the kaleidoscope example, showing the simplified usage.
