### PR TITLE
Do not corrupt textures between FBOs

### DIFF
--- a/src/ofxFXObject.cpp
+++ b/src/ofxFXObject.cpp
@@ -227,9 +227,14 @@ void ofxFXObject::setTexture(ofBaseDraws& tex, int _texNum){
     
     if ((_texNum < nTextures) && ( _texNum >= 0)){
         textures[_texNum].begin(); 
-        ofClear(0,0);
-        ofSetColor(255);
-        tex.draw(0,0); 
+        ofPushStyle();
+        {
+            ofClear(0,0);
+            ofSetColor(255);
+            ofDisableAlphaBlending(); // Defer alpha blending until .draw() to keep transparencies clean.
+            tex.draw(0,0); 
+        }
+        ofPopStyle();
         textures[_texNum].end();
     }
 };
@@ -269,7 +274,8 @@ void ofxFXObject::update(){
         // All the process it´s done on the pingPong ofxSwapBuffer ( basicaly two ofFbo that have a swap() funtion )
         pingPong.dst->begin();
         
-        ofClear(0);
+        ofClear(0,0);
+        ofDisableAlphaBlending(); // Defer alpha blending until .draw() to keep transparencies clean.
         shader.begin();
         
         // The other ofFbo of the ofxSwapBuffer can be access by calling the unicode "backbuffer"


### PR DESCRIPTION
Previously, if we set a texture (e.g. tex0) and some parts of it were transparent, all the transparent things would have been changed when doing fxobject[0].draw(...). The transparent parts would have had their alpha channel mixed with the black color due to the ofClear(0,0) call in setTexture.

Previously, textures would similarly lose their proper transparent looks when a shader was applied. This is also fixed.

Now we no longer modify transparent textures. :) Non-transparent textures still look and get modified like they used to.

[Here is a proof of concept](https://github.com/OliverUv/openframeworks_tests/tree/master/fxTest/src) showing how the behavior was bugged before this patch.

Took such a long time to fix this, but now I can use ofxFX for advanced things and I learned a lot about alpha rendering in the process! : D
