### PR TITLE
Added function to allocate with fbo settings.

### DIFF
--- a/src/ofxSwapBuffer.h
+++ b/src/ofxSwapBuffer.h
@@ -26,6 +26,20 @@ public:
         flag = 0;
     }
     
+    virtual void allocate( ofFbo::Settings settings) {
+        for(int i = 0; i < 2; i++){
+            FBOs[i].allocate(settings);
+        }
+        
+        
+        clear();
+        
+        // Set everything to 0
+        flag = 0;
+        swap();
+        flag = 0;
+    }
+    
     virtual void swap(){
         src = &(FBOs[(flag)%2]);
         dst = &(FBOs[++(flag)%2]);


### PR DESCRIPTION
I was making a lot of custom FBO settings, so I thought it made sense to make a constructor that accepted `ofFboSettings` object. This makes it a lot easier to setup the ping pong buffer.